### PR TITLE
__CARDGetFileNo - Use __CARDCompareFileName instead of strncmp

### DIFF
--- a/include/card.h
+++ b/include/card.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-#define CARD_SLOT_A             0    // Memory card slot A
-#define CARD_SLOT_B             1    // Memory card slot B
+#define CARD_SLOT_A 0 // Memory card slot A
+#define CARD_SLOT_B 1 // Memory card slot B
 
 #define CARD_FILENAME_MAX 32
 #define CARD_ICON_MAX 8

--- a/include/card_internal.h
+++ b/include/card_internal.h
@@ -5,12 +5,13 @@
 #define __CARD_INTERNAL_H__
 #include "card.h"
 #include <stddef.h>
+#include <stdbool.h>
 
 typedef struct CARDBlock {
     uint8_t unk[0x110];
 } CARDBlock;
 
-// 0x8044cbc0 in US; Specifically have to use this one and not make a new one
+// Specifically have to use this one and not make a new one
 extern CARDBlock __CARDBlock[2]; // One for each memory card slot
 
 // Vanilla functions used in main code
@@ -22,6 +23,7 @@ int32_t __CARDSync(int32_t chn);
 int32_t __CARDUpdateFatBlock(int32_t chn, void* fatBlock, CARDCallback callback);
 void* __CARDGetDirBlock(void* card);
 int32_t __CARDUpdateDir(int32_t chn, CARDCallback callback);
+bool __CARDCompareFileName(void* dirBlock, const char* fileName);
 int32_t __CARDAccess(void* card, void* dirBlock);
 
 #endif // __CARD_INTERNAL_H__

--- a/src/card.c
+++ b/src/card.c
@@ -68,12 +68,17 @@ int32_t __CARDGetFileNo(void* card, const char* fileName, int32_t* fileNo) {
     for (i = 0; i < 127; i++)
     {
         uint8_t* currentDirBlock = (uint8_t*)(dirBlock + (i * 0x40));
-        if (__CARDCompareFileName(currentDirBlock, fileName)) {
-            if (__CARDAccess(card, currentDirBlock) >= Ready) {
-                *fileNo = i;
-                break;
-            }
+        
+        if (!__CARDCompareFileName(currentDirBlock, fileName)) {
+            continue;
         }
+        
+        if (__CARDAccess(card, currentDirBlock) < Ready) {
+            continue;
+        }
+        
+        *fileNo = i;
+        break;
     }
     
     if (i >= 127) {

--- a/src/card.c
+++ b/src/card.c
@@ -4,7 +4,6 @@
 
 // We declare those instead of using the standard headers to let
 // the linker link them against the ones already in the game's code.
-int32_t strncmp(const char* str1, const char* str2, size_t n);
 void* memset(void* dst, int val, size_t n);
 
 // +=-=-=-=-=-=-=-=-=-=-=+
@@ -69,9 +68,7 @@ int32_t __CARDGetFileNo(void* card, const char* fileName, int32_t* fileNo) {
     for (i = 0; i < 127; i++)
     {
         uint8_t* currentDirBlock = (uint8_t*)(dirBlock + (i * 0x40));
-        const char* currentFileName = (const char*)(&currentDirBlock[0x8]);
-        
-        if (strncmp(fileName, currentFileName, 32) == 0) {
+        if (__CARDCompareFileName(currentDirBlock, fileName)) {
             if (__CARDAccess(card, currentDirBlock) >= Ready) {
                 *fileNo = i;
                 break;


### PR DESCRIPTION
The vanilla function inlines __CARDCompareFileName, and using it also uses less instructions overall.